### PR TITLE
docs(web): update function comment for `preprocessKeyboardEvent` - WIP

### DIFF
--- a/web/src/app/browser/src/hardwareEventKeyboard.ts
+++ b/web/src/app/browser/src/hardwareEventKeyboard.ts
@@ -39,7 +39,7 @@ export function _GetEventKeyCode(e: KeyboardEvent) {
 
 /**
  * Function     preprocessKeyboardEvent
- * @param       {Event}         e              Event object
+ * @param       {Event}         e              KeyboardEvent object
  * @param       {KeyboardState} keyboardState  Keyboard state object
  * @param       {DeviceSpec}    device         Device object
  * @return      {KeyEvent}                     KMW keyboard event object:

--- a/web/src/app/browser/src/hardwareEventKeyboard.ts
+++ b/web/src/app/browser/src/hardwareEventKeyboard.ts
@@ -38,15 +38,13 @@ export function _GetEventKeyCode(e: KeyboardEvent) {
 // Keeping this as a separate function affords us the opportunity to unit-test the method more simply.
 
 /**
- * Function     _GetKeyEventProperties
- * Scope        Private
- * @param       {Event}       e         Event object
- * @return      {Object.<string,*>}     KMW keyboard event object:
- * Description  Get object with target element, key code, shift state, virtual key state
- *                Lcode=keyCode
- *                Lmodifiers=shiftState
- *                LisVirtualKeyCode e.g. ctrl/alt key
- *                LisVirtualKey     e.g. Virtual key or non-keypress event
+ * Function     preprocessKeyboardEvent
+ * @param       {Event}         e              Event object
+ * @param       {KeyboardState} keyboardState  Keyboard state object
+ * @param       {DeviceSpec}    device         Device object
+ * @return      {KeyEvent}                     KMW keyboard event object:
+ *
+ * Description  Returns the preprocessed KeyEvent object.
  */
 export function preprocessKeyboardEvent(e: KeyboardEvent, keyboardState: KeyboardState, device: DeviceSpec): KeyEvent {
   if(e.cancelBubble === true) {


### PR DESCRIPTION
## Summary by Sourcery

Introduce a new `OutputTargetInterface` to replace `OutputTarget` across the web engine and update a low-level keyboard event helper for clearer preprocessing.

Enhancements:
- Standardize output target abstraction by replacing `OutputTarget` with `OutputTargetInterface` in function signatures, imports, exports, and class definitions across engine, keyboard, context manager, language processor, and testing code.
- Rename `_GetKeyEventProperties` to `preprocessKeyboardEvent`, update its parameters to accept `keyboardState` and `device`, and adjust documentation to reflect its return value as a preprocessed `KeyEvent`.